### PR TITLE
TaskNotesSource hardcodes http://localhost:7117 and assumes /api/tasks returns a raw array.

### DIFF
--- a/Obsync/Models/SyncConfiguration.swift
+++ b/Obsync/Models/SyncConfiguration.swift
@@ -37,6 +37,7 @@ class SyncConfiguration: ObservableObject, Codable {
     @Published var things3AuthToken: String
     @Published var taskNotesFolder: String  // Relative path within vault (e.g., "tasks")
     @Published var taskNotesIntegrationMode: String  // "cli", "file", or "http"
+    @Published var taskNotesApiPort: Int
 
     enum TaskSourceType: String, Codable, CaseIterable {
         case obsidianTasks = "obsidianTasks"
@@ -87,6 +88,8 @@ class SyncConfiguration: ObservableObject, Codable {
         case enableNewTaskWriteback, inboxFilePath, enableFileWatcher
         case enableNotifications, globalHotKeyEnabled, globalHotKeyCode, globalHotKeyModifiers
         case taskSourceType, taskDestinationType, things3AuthToken, taskNotesFolder, taskNotesIntegrationMode
+        case taskNotesApiPort
+        case taskNotesApiBaseUrl  // Legacy key for migration from URL-based setting
     }
 
     init(
@@ -121,7 +124,8 @@ class SyncConfiguration: ObservableObject, Codable {
         taskDestinationType: TaskDestinationType = .appleReminders,
         things3AuthToken: String = "",
         taskNotesFolder: String = "",
-        taskNotesIntegrationMode: String = "cli"
+        taskNotesIntegrationMode: String = "cli",
+        taskNotesApiPort: Int = 8080
     ) {
         self.vaultPath = vaultPath
         self.syncIntervalMinutes = syncIntervalMinutes
@@ -155,6 +159,7 @@ class SyncConfiguration: ObservableObject, Codable {
         self.things3AuthToken = things3AuthToken
         self.taskNotesFolder = taskNotesFolder
         self.taskNotesIntegrationMode = taskNotesIntegrationMode
+        self.taskNotesApiPort = taskNotesApiPort
     }
 
     required init(from decoder: Decoder) throws {
@@ -191,6 +196,18 @@ class SyncConfiguration: ObservableObject, Codable {
         things3AuthToken = try container.decodeIfPresent(String.self, forKey: .things3AuthToken) ?? ""
         taskNotesFolder = try container.decodeIfPresent(String.self, forKey: .taskNotesFolder) ?? ""
         taskNotesIntegrationMode = try container.decodeIfPresent(String.self, forKey: .taskNotesIntegrationMode) ?? "cli"
+        if let decodedPort = try container.decodeIfPresent(Int.self, forKey: .taskNotesApiPort),
+           (1...65535).contains(decodedPort) {
+            taskNotesApiPort = decodedPort
+        } else if
+            let legacyApiBaseUrl = try container.decodeIfPresent(String.self, forKey: .taskNotesApiBaseUrl),
+            let url = URL(string: legacyApiBaseUrl),
+            let legacyPort = url.port,
+            (1...65535).contains(legacyPort) {
+            taskNotesApiPort = legacyPort
+        } else {
+            taskNotesApiPort = 8080
+        }
     }
 
     func encode(to encoder: Encoder) throws {
@@ -227,6 +244,7 @@ class SyncConfiguration: ObservableObject, Codable {
         try container.encode(things3AuthToken, forKey: .things3AuthToken)
         try container.encode(taskNotesFolder, forKey: .taskNotesFolder)
         try container.encode(taskNotesIntegrationMode, forKey: .taskNotesIntegrationMode)
+        try container.encode(taskNotesApiPort, forKey: .taskNotesApiPort)
     }
 
     // MARK: - Persistence

--- a/Obsync/Services/SyncManager.swift
+++ b/Obsync/Services/SyncManager.swift
@@ -83,6 +83,7 @@ class SyncManager: ObservableObject {
             let source = TaskNotesSource()
             if let config = config {
                 source.integrationMode = TaskNotesSource.IntegrationMode(rawValue: config.taskNotesIntegrationMode) ?? .cli
+                source.apiPort = config.taskNotesApiPort
             }
             return source
         }
@@ -173,6 +174,7 @@ class SyncManager: ObservableObject {
             debugLog("[SyncManager] Skipped: already syncing")
             return
         }
+        updateSourceAndDestination()
         guard hasRemindersAccess else {
             showErrorMessage("No access to Reminders. Please grant permission in System Settings.")
             return

--- a/Obsync/Views/SettingsView.swift
+++ b/Obsync/Views/SettingsView.swift
@@ -340,6 +340,28 @@ struct AdvancedSettingsView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .padding(.leading, 20)
+
+                        HStack {
+                            Text("API Port:")
+                                .foregroundColor(.secondary)
+                            TextField("8080", text: Binding(
+                                get: { String(syncManager.config.taskNotesApiPort) },
+                                set: { value in
+                                    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                                    if trimmed.isEmpty {
+                                        syncManager.config.taskNotesApiPort = 8080
+                                        return
+                                    }
+
+                                    if let port = Int(trimmed), (1...65535).contains(port) {
+                                        syncManager.config.taskNotesApiPort = port
+                                    }
+                                }
+                            ))
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 120)
+                        }
+                        .padding(.leading, 20)
                     }
 
                     HStack {


### PR DESCRIPTION

This pull request enhances the integration with the TaskNotes HTTP API by making the API port configurable, improving error handling and compatibility with various API response formats, and refining notification permission logic. The most significant changes are grouped below:

**TaskNotes HTTP API Integration Improvements:**

* The TaskNotes API port is now configurable via the new `taskNotesApiPort` property in `SyncConfiguration`, with UI support in `AdvancedSettingsView` and proper migration logic for legacy settings. The default port is 8080. (`Obsync/Models/SyncConfiguration.swift` [[1]](diffhunk://#diff-836aacab0eaf90b5a203bf4e22696f2a18e31ec8eaf9b72afce68ea3e45e33dcR40) [[2]](diffhunk://#diff-836aacab0eaf90b5a203bf4e22696f2a18e31ec8eaf9b72afce68ea3e45e33dcR91-R92) [[3]](diffhunk://#diff-836aacab0eaf90b5a203bf4e22696f2a18e31ec8eaf9b72afce68ea3e45e33dcL124-R128) [[4]](diffhunk://#diff-836aacab0eaf90b5a203bf4e22696f2a18e31ec8eaf9b72afce68ea3e45e33dcR162) [[5]](diffhunk://#diff-836aacab0eaf90b5a203bf4e22696f2a18e31ec8eaf9b72afce68ea3e45e33dcR199-R210) [[6]](diffhunk://#diff-836aacab0eaf90b5a203bf4e22696f2a18e31ec8eaf9b72afce68ea3e45e33dcR247); `Obsync/Views/SettingsView.swift` [[7]](diffhunk://#diff-5bee398babd3261354a26b6bb3c9e4086e00cc2fc28fada184bb5721f7e04961R343-R364)
* The `TaskNotesSource` now uses the configurable API port, and the `scanTasksViaApi` method has been refactored for more robust error handling, including HTTP status checks and detailed error messages. (`Obsync/Services/Sources/TaskNotesSource.swift` [[1]](diffhunk://#diff-6a12478328616588dfd2d5a8a69ef9800e9a97fe1e1867ec218084bb655bc93bL58-R59) [[2]](diffhunk://#diff-6a12478328616588dfd2d5a8a69ef9800e9a97fe1e1867ec218084bb655bc93bL172-R172) [[3]](diffhunk://#diff-6a12478328616588dfd2d5a8a69ef9800e9a97fe1e1867ec218084bb655bc93bL689-R759) [[4]](diffhunk://#diff-6a12478328616588dfd2d5a8a69ef9800e9a97fe1e1867ec218084bb655bc93bL717-R777)
* The API task response parser now supports multiple envelope formats (`tasks`, `items`, `results`) to maximize compatibility with different TaskNotes plugin versions. (`Obsync/Services/Sources/TaskNotesSource.swift` [Obsync/Services/Sources/TaskNotesSource.swiftR930-R942](diffhunk://#diff-6a12478328616588dfd2d5a8a69ef9800e9a97fe1e1867ec218084bb655bc93bR930-R942))
* The `SyncManager` now passes the configured API port to `TaskNotesSource` and ensures the source/destination is updated before each sync. (`Obsync/Services/SyncManager.swift` [[1]](diffhunk://#diff-698597d70dc5a9a819a5e4a80236a787d0a44403ebc6c144fe1c18e21122215fR86) [[2]](diffhunk://#diff-698597d70dc5a9a819a5e4a80236a787d0a44403ebc6c144fe1c18e21122215fR177)

**Notification Permission and Error Handling:**

* Notification permission requests now check the current authorization status before prompting, and all notification scheduling errors are logged with detailed messages for better diagnostics. (`Obsync/Services/NotificationService.swift` [[1]](diffhunk://#diff-84588404c40d2485de12b357ee9d1d445a94e592fbff8f653c8e34c3ae5f371cL14-R36) [[2]](diffhunk://#diff-84588404c40d2485de12b357ee9d1d445a94e592fbff8f653c8e34c3ae5f371cL33-R60)
- Patch HTTP API parsing to support common wrapped responses ({ success, data: [...] }) and tighten error details.
- Added configuration for port to Settings