### PR TITLE
Fix: retry transient EventKit errors with actionable messages

### DIFF
--- a/Obsync/Services/Destinations/RemindersDestination.swift
+++ b/Obsync/Services/Destinations/RemindersDestination.swift
@@ -9,6 +9,11 @@ class RemindersDestination: TaskDestination {
     private let eventStore = EKEventStore()
     private var hasAccess = false
 
+    /// Max retry attempts for transient EventKit failures.
+    private let maxRetries = 3
+    /// Base delay between retries (doubles each attempt).
+    private let baseRetryDelay: TimeInterval = 0.5
+
     // MARK: - Authorization
 
     func requestAccess() async throws -> Bool {
@@ -59,7 +64,9 @@ class RemindersDestination: TaskDestination {
             addTaskLink: config.addTaskLinkToReminders,
             vaultPath: config.vaultPath
         )
-        try eventStore.save(reminder, commit: true)
+        try await retryEventKitOperation(label: "create '\(task.title)'") {
+            try self.eventStore.save(reminder, commit: true)
+        }
         return reminder.calendarItemIdentifier
     }
 
@@ -73,7 +80,9 @@ class RemindersDestination: TaskDestination {
             addTaskLink: config.addTaskLinkToReminders,
             vaultPath: config.vaultPath
         )
-        try eventStore.save(reminder, commit: true)
+        try await retryEventKitOperation(label: "update '\(task.title)'") {
+            try self.eventStore.save(reminder, commit: true)
+        }
     }
 
     func moveTask(withId id: String, toList listName: String) async throws {
@@ -82,18 +91,58 @@ class RemindersDestination: TaskDestination {
         }
         let list = try getOrCreateList(named: listName)
         reminder.calendar = list
-        try eventStore.save(reminder, commit: true)
+        try await retryEventKitOperation(label: "move to '\(listName)'") {
+            try self.eventStore.save(reminder, commit: true)
+        }
     }
 
     func deleteTask(withId id: String) async throws {
         guard let reminder = eventStore.calendarItem(withIdentifier: id) as? EKReminder else {
             throw RemindersError.reminderNotFound(id)
         }
-        try eventStore.remove(reminder, commit: true)
+        try await retryEventKitOperation(label: "delete") {
+            try self.eventStore.remove(reminder, commit: true)
+        }
     }
 
     func refresh() {
         eventStore.reset()
+    }
+
+    // MARK: - Retry Logic
+
+    /// Retry an EventKit save/remove operation with exponential backoff.
+    /// Resets the event store between retries to clear stale cache state.
+    private func retryEventKitOperation(label: String, operation: () throws -> Void) async throws {
+        var lastError: Error?
+        for attempt in 1...maxRetries {
+            do {
+                try operation()
+                return
+            } catch {
+                lastError = error
+                let isTransient = Self.isTransientEventKitError(error)
+                debugLog("[RemindersDestination] \(label) attempt \(attempt)/\(maxRetries) failed: \(error.localizedDescription) (transient: \(isTransient))")
+                if !isTransient || attempt == maxRetries { break }
+                // Reset store to clear stale cache, then wait before retry
+                eventStore.reset()
+                let delay = baseRetryDelay * pow(2.0, Double(attempt - 1))
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+        }
+        throw EventKitSyncError.from(lastError!)
+    }
+
+    /// Determine if an EventKit error is transient and worth retrying.
+    private static func isTransientEventKitError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        // ReminderKit/EventKit internal errors (e.g. -3002 database sync issues)
+        if nsError.domain == "com.apple.reminderkit" { return true }
+        if nsError.domain == "EKErrorDomain" {
+            // EKErrorInternalFailure (code 0) and similar transient codes
+            return nsError.code == 0 || nsError.code == 1
+        }
+        return false
     }
 
     // MARK: - Private Helpers
@@ -118,5 +167,46 @@ class RemindersDestination: TaskDestination {
 
         try eventStore.saveCalendar(newList, commit: true)
         return newList
+    }
+}
+
+// MARK: - EventKit Error Translation
+
+/// User-friendly wrapper for EventKit/ReminderKit errors with actionable messages.
+struct EventKitSyncError: LocalizedError {
+    let underlyingError: Error
+    let userMessage: String
+
+    var errorDescription: String? { userMessage }
+
+    static func from(_ error: Error) -> EventKitSyncError {
+        let nsError = error as NSError
+        let userMessage: String
+
+        if nsError.domain == "com.apple.reminderkit" {
+            switch nsError.code {
+            case -3002:
+                userMessage = "Reminders database sync conflict. Try restarting Reminders.app or toggling iCloud Reminders off and on in System Settings."
+            case -3999...(-3001):
+                userMessage = "Reminders internal error (\(nsError.code)). Restarting Reminders.app or rebooting may help."
+            default:
+                userMessage = "Reminders error (\(nsError.code)): \(nsError.localizedDescription)"
+            }
+        } else if nsError.domain == "EKErrorDomain" {
+            switch nsError.code {
+            case 0:
+                userMessage = "EventKit internal failure. Try rebooting to reset the Reminders daemon."
+            case 1:
+                userMessage = "Reminder was modified by another app during sync. The next sync should resolve this."
+            case 14:
+                userMessage = "Calendar source is read-only. Check that your Reminders account allows modifications."
+            default:
+                userMessage = "EventKit error (\(nsError.code)): \(nsError.localizedDescription)"
+            }
+        } else {
+            userMessage = error.localizedDescription
+        }
+
+        return EventKitSyncError(underlyingError: error, userMessage: userMessage)
     }
 }

--- a/Obsync/Services/SyncEngine.swift
+++ b/Obsync/Services/SyncEngine.swift
@@ -148,6 +148,11 @@ class SyncEngine {
         // Capture file timestamps at sync start (for change detection during writes)
         let syncStartTimestamp = Date()
 
+        // Reset the destination's internal cache before syncing to clear stale state
+        // (prevents errors like ReminderKit -3002 from lingering across syncs)
+        destination.refresh()
+        debugLog("[SyncEngine] Destination cache refreshed")
+
         do {
             // Step 1: Get all tasks from source
             debugLog("[SyncEngine] Scanning source: \(source.sourceName)")

--- a/Obsync/Services/SyncManager.swift
+++ b/Obsync/Services/SyncManager.swift
@@ -306,9 +306,21 @@ class SyncManager: ObservableObject {
         if result.errors.isEmpty {
             statusMessage = result.summary
         } else {
-            let errorMessages = result.errors.map { $0.localizedDescription }.joined(separator: "\n")
-            showErrorMessage("Sync completed with errors:\n\(errorMessages)")
-            statusMessage = "Sync completed with \(result.errors.count) errors"
+            // Deduplicate identical error messages (e.g. multiple -3002 errors)
+            var seen = Set<String>()
+            var uniqueMessages: [String] = []
+            for error in result.errors {
+                let msg = error.localizedDescription
+                if seen.insert(msg).inserted {
+                    uniqueMessages.append(msg)
+                }
+            }
+            let errorSummary = uniqueMessages.joined(separator: "\n")
+            let countNote = result.errors.count > uniqueMessages.count
+                ? " (\(result.errors.count) total)"
+                : ""
+            showErrorMessage("Sync completed with errors\(countNote):\n\(errorSummary)")
+            statusMessage = "Sync completed with \(result.errors.count) error\(result.errors.count == 1 ? "" : "s")"
         }
 
         isSyncing = false


### PR DESCRIPTION
## Summary

- **Retry with backoff** — EventKit save/remove operations in `RemindersDestination` now retry up to 3 times with exponential backoff (0.5s → 1s → 2s) for transient errors like ReminderKit `-3002`. The event store cache is reset between attempts.
- **Cache reset before sync** — `SyncEngine` now calls `destination.refresh()` (i.e. `eventStore.reset()`) at the start of every sync to clear stale EventKit state before any operations begin.
- **Human-readable error messages** — A new `EventKitSyncError` type translates cryptic ReminderKit/EventKit error codes into actionable suggestions (e.g. `-3002` → *"Reminders database sync conflict. Try restarting Reminders.app or toggling iCloud Reminders off and on in System Settings."*). Duplicate errors are deduplicated in the UI.

## Context

I was getting repeated `com.apple.reminderkit error -3002` errors during sync with no indication of what was wrong or how to fix it. Restarting Remindian did not help. These changes resolved the issue for me — the retry logic recovers from transient failures automatically, and when errors do persist, the messages now tell the user what to try.

## Test plan

- [ ] Trigger a sync with Apple Reminders as the destination and verify normal operation is unaffected
- [ ] Verify that transient EventKit errors are retried (visible in `debug.log` as retry attempt lines)
- [ ] Confirm that repeated identical errors are deduplicated in the error dialog
- [ ] Check that non-Reminders destinations (Things 3, Todoist, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)