### PR TITLE
Apply maxCompletedTaskAgeDays to destination → source writeback

### DIFF
--- a/ObsidianRemindersSync.xcodeproj/project.pbxproj
+++ b/ObsidianRemindersSync.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		T09 /* TickTickOAuthServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T18; };
 		T0A /* InboxWritebackRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T19; };
 		T0B /* V5_9_0_RegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1A; };
+		T0C /* AgeFilterWritebackRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -116,6 +117,7 @@
 		T18 /* TickTickOAuthServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickTickOAuthServerTests.swift; sourceTree = "<group>"; };
 		T19 /* InboxWritebackRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxWritebackRegressionTests.swift; sourceTree = "<group>"; };
 		T1A /* V5_9_0_RegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V5_9_0_RegressionTests.swift; sourceTree = "<group>"; };
+		T1B /* AgeFilterWritebackRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeFilterWritebackRegressionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -260,6 +262,7 @@
 				T18 /* TickTickOAuthServerTests.swift */,
 				T19 /* InboxWritebackRegressionTests.swift */,
 				T1A /* V5_9_0_RegressionTests.swift */,
+				T1B /* AgeFilterWritebackRegressionTests.swift */,
 			);
 			path = RemindianTests;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				T09 /* TickTickOAuthServerTests.swift in Sources */,
 				T0A /* InboxWritebackRegressionTests.swift in Sources */,
 				T0B /* V5_9_0_RegressionTests.swift in Sources */,
+				T0C /* AgeFilterWritebackRegressionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Obsync/Services/SyncEngine.swift
+++ b/Obsync/Services/SyncEngine.swift
@@ -98,6 +98,26 @@ class SyncEngine {
         }
     }
 
+    // MARK: - Filters
+
+    /// True if a completed task is older than `config.maxCompletedTaskAgeDays`
+    /// and should be excluded from sync. Uncompleted tasks are never filtered.
+    /// Returns false when the setting is disabled (<= 0).
+    ///
+    /// Used in two places: the source scan (Step 1) and the Reminders → Obsidian
+    /// writeback loop (Step 6). Without applying it on both sides, a user with
+    /// `enableNewTaskWriteback = true` and a long history of completed reminders
+    /// gets every old completion written into the vault on next sync, which is
+    /// exactly the symptom #11 was filed for.
+    static func isCompletedTaskTooOld(_ task: SyncTask, config: SyncConfiguration) -> Bool {
+        guard config.maxCompletedTaskAgeDays > 0, task.isCompleted else { return false }
+        let cutoffDate = Calendar.current.date(byAdding: .day, value: -config.maxCompletedTaskAgeDays, to: Date()) ?? Date()
+        if let completedDate = task.completedDate {
+            return completedDate <= cutoffDate
+        }
+        return task.lastModified <= cutoffDate
+    }
+
     // MARK: - Main Sync
 
     /// Perform sync: Source -> Destination (source is the source of truth).
@@ -160,15 +180,8 @@ class SyncEngine {
 
             // Filter out old completed tasks if configured
             if config.maxCompletedTaskAgeDays > 0 {
-                let cutoffDate = Calendar.current.date(byAdding: .day, value: -config.maxCompletedTaskAgeDays, to: Date()) ?? Date()
                 let beforeCount = obsidianTasks.count
-                obsidianTasks = obsidianTasks.filter { task in
-                    guard task.isCompleted else { return true }
-                    if let completedDate = task.completedDate {
-                        return completedDate > cutoffDate
-                    }
-                    return task.lastModified > cutoffDate
-                }
+                obsidianTasks = obsidianTasks.filter { !SyncEngine.isCompletedTaskTooOld($0, config: config) }
                 let filtered = beforeCount - obsidianTasks.count
                 if filtered > 0 {
                     debugLog("[SyncEngine] Filtered out \(filtered) completed tasks older than \(config.maxCompletedTaskAgeDays) days")
@@ -1044,9 +1057,21 @@ class SyncEngine {
                     titleIndex[task.title] = id
                 }
 
+                // Counter for the age-filter log line below — mirrors the source-scan
+                // "Filtered out N completed tasks older than N days" pattern.
+                var skippedOldCount = 0
+
                 for (remindersId, rTask) in remindersMap {
                     // Skip completed tasks unless configured to sync them
                     if rTask.isCompleted && !config.syncCompletedTasks { continue }
+
+                    // Honor maxCompletedTaskAgeDays in both directions. Without this,
+                    // old completed reminders bypass the age cutoff via the writeback
+                    // path — exactly the symptom #11 was filed for.
+                    if SyncEngine.isCompletedTaskTooOld(rTask, config: config) {
+                        skippedOldCount += 1
+                        continue
+                    }
 
                     // CRITICAL: skip reminders whose title already exists anywhere in
                     // the vault. Without this, Apple Reminders' recurring-task history
@@ -1125,6 +1150,10 @@ class SyncEngine {
                             errorMessage: "Inbox writeback failed: \(error.localizedDescription)"
                         ))
                     }
+                }
+
+                if skippedOldCount > 0 {
+                    debugLog("[SyncEngine] Skipped \(skippedOldCount) old completed reminders from inbox writeback (older than \(config.maxCompletedTaskAgeDays) days)")
                 }
             }
 

--- a/Obsync/Services/SyncEngine.swift
+++ b/Obsync/Services/SyncEngine.swift
@@ -8,11 +8,20 @@ class SyncEngine {
     private let source: TaskSource
     private let destination: TaskDestination
     private let backupService = FileBackupService.shared
-    private var syncState = SyncState.load()
+    private var syncState: SyncState
 
-    init(source: TaskSource, destination: TaskDestination) {
+    /// Production init — loads sync state from disk.
+    convenience init(source: TaskSource, destination: TaskDestination) {
+        self.init(source: source, destination: destination, syncState: SyncState.load())
+    }
+
+    /// Designated init exposing the SyncState seam so tests can drive
+    /// `performSync(...)` without touching the real Application Support
+    /// directory. Production callers should use the convenience init above.
+    init(source: TaskSource, destination: TaskDestination, syncState: SyncState) {
         self.source = source
         self.destination = destination
+        self.syncState = syncState
     }
 
     // Mutex to prevent concurrent sync operations
@@ -100,22 +109,41 @@ class SyncEngine {
 
     // MARK: - Filters
 
-    /// True if a completed task is older than `config.maxCompletedTaskAgeDays`
-    /// and should be excluded from sync. Uncompleted tasks are never filtered.
-    /// Returns false when the setting is disabled (<= 0).
+    /// Compute the completed-task age cutoff for this sync. Returns nil when
+    /// the filter is disabled (`maxCompletedTaskAgeDays <= 0`).
+    ///
+    /// Computed once per sync — callers pass the resulting cutoff into
+    /// `isCompletedTaskTooOld(_:cutoff:)` for every task. This keeps the cutoff
+    /// stable across all tasks evaluated in the same sync (rather than
+    /// re-sampling `Date()` per task) and concentrates the calendar-arithmetic
+    /// fallback in one place.
+    ///
+    /// The `.distantPast` fallback (used when `Calendar.current.date(byAdding:)`
+    /// returns nil) means a calendar-arithmetic failure degrades to "keep
+    /// everything" — anything compared against `distantPast` with `<=` is false.
+    /// The earlier `?? Date()` fallback had the opposite effect: cutoff = now
+    /// silently filtered every completed task.
+    static func completedTaskCutoffDate(for config: SyncConfiguration) -> Date? {
+        guard config.maxCompletedTaskAgeDays > 0 else { return nil }
+        return Calendar.current.date(byAdding: .day, value: -config.maxCompletedTaskAgeDays, to: Date()) ?? .distantPast
+    }
+
+    /// True if a completed task is older than the supplied cutoff and should
+    /// be excluded from sync. Uncompleted tasks and a nil cutoff (filter
+    /// disabled) always return false. Falls back to `lastModified` when
+    /// `completedDate` is missing — matches the legacy source-scan behavior.
     ///
     /// Used in two places: the source scan (Step 1) and the Reminders → Obsidian
     /// writeback loop (Step 6). Without applying it on both sides, a user with
     /// `enableNewTaskWriteback = true` and a long history of completed reminders
-    /// gets every old completion written into the vault on next sync, which is
-    /// exactly the symptom #11 was filed for.
-    static func isCompletedTaskTooOld(_ task: SyncTask, config: SyncConfiguration) -> Bool {
-        guard config.maxCompletedTaskAgeDays > 0, task.isCompleted else { return false }
-        let cutoffDate = Calendar.current.date(byAdding: .day, value: -config.maxCompletedTaskAgeDays, to: Date()) ?? Date()
+    /// gets every old completion written into the vault on next sync — exactly
+    /// the symptom #11 was filed for.
+    static func isCompletedTaskTooOld(_ task: SyncTask, cutoff: Date?) -> Bool {
+        guard let cutoff, task.isCompleted else { return false }
         if let completedDate = task.completedDate {
-            return completedDate <= cutoffDate
+            return completedDate <= cutoff
         }
-        return task.lastModified <= cutoffDate
+        return task.lastModified <= cutoff
     }
 
     // MARK: - Main Sync
@@ -179,9 +207,9 @@ class SyncEngine {
             debugLog("[SyncEngine] Found \(obsidianTasks.count) source tasks")
 
             // Filter out old completed tasks if configured
-            if config.maxCompletedTaskAgeDays > 0 {
+            if let sourceCutoff = SyncEngine.completedTaskCutoffDate(for: config) {
                 let beforeCount = obsidianTasks.count
-                obsidianTasks = obsidianTasks.filter { !SyncEngine.isCompletedTaskTooOld($0, config: config) }
+                obsidianTasks = obsidianTasks.filter { !SyncEngine.isCompletedTaskTooOld($0, cutoff: sourceCutoff) }
                 let filtered = beforeCount - obsidianTasks.count
                 if filtered > 0 {
                     debugLog("[SyncEngine] Filtered out \(filtered) completed tasks older than \(config.maxCompletedTaskAgeDays) days")
@@ -1057,6 +1085,10 @@ class SyncEngine {
                     titleIndex[task.title] = id
                 }
 
+                // Cutoff computed once per sync — keeps filter decisions stable
+                // across all reminders evaluated in the same writeback pass.
+                let writebackCutoff = SyncEngine.completedTaskCutoffDate(for: config)
+
                 // Counter for the age-filter log line below — mirrors the source-scan
                 // "Filtered out N completed tasks older than N days" pattern.
                 var skippedOldCount = 0
@@ -1064,14 +1096,6 @@ class SyncEngine {
                 for (remindersId, rTask) in remindersMap {
                     // Skip completed tasks unless configured to sync them
                     if rTask.isCompleted && !config.syncCompletedTasks { continue }
-
-                    // Honor maxCompletedTaskAgeDays in both directions. Without this,
-                    // old completed reminders bypass the age cutoff via the writeback
-                    // path — exactly the symptom #11 was filed for.
-                    if SyncEngine.isCompletedTaskTooOld(rTask, config: config) {
-                        skippedOldCount += 1
-                        continue
-                    }
 
                     // CRITICAL: skip reminders whose title already exists anywhere in
                     // the vault. Without this, Apple Reminders' recurring-task history
@@ -1082,6 +1106,13 @@ class SyncEngine {
                     // and re-appending it adds noise. We attach the existing
                     // obsidianId to the reminder's mapping instead so subsequent
                     // syncs treat it as already-mapped. (regression: 2026-04-30)
+                    //
+                    // This block runs BEFORE the age filter below so the mapping
+                    // side-effect still fires for old-and-title-matched reminders —
+                    // otherwise an old recurring-task occurrence whose title matches
+                    // a vault task would skip via age every sync without ever getting
+                    // a syncState mapping, and the noisy "Skipped N" count would
+                    // include it perpetually.
                     if let existingObsidianId = titleIndex[rTask.title] {
                         if !config.dryRunMode,
                            let matchedObsidianTask = obsidianMap[existingObsidianId] {
@@ -1093,6 +1124,16 @@ class SyncEngine {
                             )
                         }
                         debugLog("[SyncEngine] Skipping inbox writeback for \"\(rTask.title)\": title already exists in vault (mapped to existing task)")
+                        continue
+                    }
+
+                    // Honor maxCompletedTaskAgeDays in both directions. Without this,
+                    // old completed reminders bypass the age cutoff via the writeback
+                    // path — exactly the symptom #11 was filed for. Runs AFTER the
+                    // title-dedup above so the dedup's mapping side-effect is
+                    // preserved for old-and-title-matched reminders.
+                    if SyncEngine.isCompletedTaskTooOld(rTask, cutoff: writebackCutoff) {
+                        skippedOldCount += 1
                         continue
                     }
 

--- a/RemindianTests/AgeFilterWritebackRegressionTests.swift
+++ b/RemindianTests/AgeFilterWritebackRegressionTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import Remindian
+
+/// Regression tests for the `maxCompletedTaskAgeDays` filter asymmetry.
+///
+/// **The bug.** The age cutoff was applied to the source scan (Step 1) but not
+/// to the Reminders → Obsidian writeback (Step 6). With
+/// `enableNewTaskWriteback = true` and a long history of completed reminders,
+/// every old completion was eligible for writeback into the source vault on
+/// next sync — recreating the exact symptom that #11 was filed for (and that
+/// v3.3.0 only half-fixed by adding the setting).
+///
+/// **The fix.** Extract the inline source-side filter into
+/// `SyncEngine.isCompletedTaskTooOld(_:config:)` and reuse it in the writeback
+/// loop. These tests guard each of the cases the helper must get right.
+final class AgeFilterWritebackRegressionTests: XCTestCase {
+
+    private func config(maxAgeDays: Int) -> SyncConfiguration {
+        var c = SyncConfiguration()
+        c.maxCompletedTaskAgeDays = maxAgeDays
+        c.syncCompletedTasks = true
+        c.enableNewTaskWriteback = true
+        return c
+    }
+
+    private func daysAgo(_ n: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -n, to: Date())!
+    }
+
+    // MARK: - Old completed reminders are filtered
+
+    /// A reminder completed 31 days ago, when `maxCompletedTaskAgeDays = 30`,
+    /// must be filtered. Without this check the writeback loop would call
+    /// `appendNewTask` for it.
+    func testOldCompletedReminderIsFilteredByHelper() {
+        let task = SyncTask(
+            title: "Old completed reminder",
+            isCompleted: true,
+            completedDate: daysAgo(31)
+        )
+        XCTAssertTrue(
+            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            "Reminder completed 31 days ago must be filtered when maxCompletedTaskAgeDays=30. Without this, old completed reminders bypass the cutoff via the writeback path. (regression: #11 part 2)"
+        )
+    }
+
+    /// Fallback path: when a completed task has no `completedDate`, the helper
+    /// uses `lastModified` instead. Mirrors the source-scan behavior.
+    func testCompletedReminderWithoutCompletedDateFallsBackToLastModified() {
+        var task = SyncTask(
+            title: "Completed but no completedDate",
+            isCompleted: true,
+            completedDate: nil
+        )
+        task.lastModified = daysAgo(60)
+        XCTAssertTrue(
+            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            "When completedDate is nil, lastModified must be consulted. The source-scan filter does this; writeback must match."
+        )
+    }
+
+    // MARK: - Recent completed reminders are kept (negative case)
+
+    /// A reminder completed 5 days ago must NOT be filtered when the cutoff is
+    /// 30 days. Catches over-filtering — i.e. the helper accidentally returning
+    /// true for in-window tasks.
+    func testRecentCompletedReminderIsNotFiltered() {
+        let task = SyncTask(
+            title: "Recently completed reminder",
+            isCompleted: true,
+            completedDate: daysAgo(5)
+        )
+        XCTAssertFalse(
+            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            "Reminder completed within the 30-day window must NOT be filtered — that would over-correct and hide legitimate recent work."
+        )
+    }
+
+    // MARK: - Uncompleted reminders are always kept
+
+    /// An uncompleted reminder must never be filtered by this helper, regardless
+    /// of how stale `lastModified` is. The age cutoff is about completion age
+    /// only; an open task is still actionable.
+    func testUncompletedReminderIsNeverFilteredEvenIfStale() {
+        var task = SyncTask(
+            title: "Old open reminder",
+            isCompleted: false,
+            completedDate: nil
+        )
+        task.lastModified = daysAgo(365)
+        XCTAssertFalse(
+            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            "Uncompleted tasks must never be age-filtered. Open work doesn't expire."
+        )
+    }
+
+    // MARK: - Disabled setting
+
+    /// `maxCompletedTaskAgeDays = 0` (the disabled sentinel) must short-circuit
+    /// to false. This preserves opt-in behavior — users who explicitly turn the
+    /// setting off get the old "sync everything" behavior, including via
+    /// writeback.
+    func testDisabledSettingNeverFilters() {
+        let task = SyncTask(
+            title: "Ancient completed reminder",
+            isCompleted: true,
+            completedDate: daysAgo(3650)
+        )
+        XCTAssertFalse(
+            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 0)),
+            "When maxCompletedTaskAgeDays is 0 (disabled), the helper must return false for everything — otherwise toggling the setting off would silently break sync."
+        )
+    }
+
+    /// Boundary case: a task completed exactly `maxCompletedTaskAgeDays` ago
+    /// is inside the window. We use `<=` against the cutoff date, which is
+    /// `now - N days`, so a `completedDate` of exactly that point is treated as
+    /// too old (matches the source-scan semantics: source uses `>` to KEEP, so
+    /// equal-to-cutoff is dropped on source too — the helper must match).
+    func testBoundaryCaseMatchesSourceScanSemantics() {
+        // Reminder completed exactly at the cutoff instant. Source scan uses
+        // `completedDate > cutoffDate` to keep, so equal-to-cutoff is filtered.
+        // Helper must agree.
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
+        var task = SyncTask(
+            title: "Edge case",
+            isCompleted: true,
+            completedDate: cutoff
+        )
+        task.lastModified = cutoff
+        XCTAssertTrue(
+            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            "Boundary semantics must match source-scan filter. Source uses `> cutoff` to keep, so equal-to-cutoff is dropped; helper does the same with `<= cutoff`."
+        )
+    }
+}

--- a/RemindianTests/AgeFilterWritebackRegressionTests.swift
+++ b/RemindianTests/AgeFilterWritebackRegressionTests.swift
@@ -10,10 +10,27 @@ import XCTest
 /// next sync — recreating the exact symptom that #11 was filed for (and that
 /// v3.3.0 only half-fixed by adding the setting).
 ///
-/// **The fix.** Extract the inline source-side filter into
-/// `SyncEngine.isCompletedTaskTooOld(_:config:)` and reuse it in the writeback
-/// loop. These tests guard each of the cases the helper must get right.
+/// **The fix.** Split the filter into two helpers:
+///   * `SyncEngine.completedTaskCutoffDate(for:)` — compute the cutoff once
+///     per sync; returns nil when the filter is disabled.
+///   * `SyncEngine.isCompletedTaskTooOld(_:cutoff:)` — pure comparison.
+/// Both the source scan (Step 1) and the writeback loop (Step 6) call the
+/// pair. In the writeback loop the age filter runs AFTER the v5.8.2 title-
+/// dedup so the dedup's `syncState.addOrUpdateMapping(...)` side-effect is
+/// preserved for old reminders whose titles match an existing vault task.
+///
+/// The tests split into two groups: pure helper unit tests at the top, then
+/// integration tests at the bottom that drive `SyncEngine.performSync(...)`
+/// with mock `TaskSource` / `TaskDestination` so the writeback site itself is
+/// exercised — without these, a future refactor that inverts or removes the
+/// `if` at the writeback call site would pass the unit tests but reintroduce
+/// the bug.
 final class AgeFilterWritebackRegressionTests: XCTestCase {
+
+    // Fixed Gregorian calendar so the test is robust to CI machines running
+    // under non-Gregorian default locales (Hebrew, Buddhist, Japanese, ...).
+    // Force-unwrapping `Calendar.current.date(byAdding:)` would crash there.
+    private let gregorian = Calendar(identifier: .gregorian)
 
     private func config(maxAgeDays: Int) -> SyncConfiguration {
         var c = SyncConfiguration()
@@ -23,114 +40,318 @@ final class AgeFilterWritebackRegressionTests: XCTestCase {
         return c
     }
 
-    private func daysAgo(_ n: Int) -> Date {
-        Calendar.current.date(byAdding: .day, value: -n, to: Date())!
+    private func daysAgo(_ n: Int) throws -> Date {
+        try XCTUnwrap(gregorian.date(byAdding: .day, value: -n, to: Date()))
     }
 
-    // MARK: - Old completed reminders are filtered
+    private func cutoff(maxAgeDays: Int) -> Date? {
+        SyncEngine.completedTaskCutoffDate(for: config(maxAgeDays: maxAgeDays))
+    }
+
+    // MARK: - Helper unit tests
 
     /// A reminder completed 31 days ago, when `maxCompletedTaskAgeDays = 30`,
-    /// must be filtered. Without this check the writeback loop would call
-    /// `appendNewTask` for it.
-    func testOldCompletedReminderIsFilteredByHelper() {
+    /// must be filtered.
+    func testOldCompletedReminderIsFilteredByHelper() throws {
         let task = SyncTask(
             title: "Old completed reminder",
             isCompleted: true,
-            completedDate: daysAgo(31)
+            completedDate: try daysAgo(31)
         )
         XCTAssertTrue(
-            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            SyncEngine.isCompletedTaskTooOld(task, cutoff: cutoff(maxAgeDays: 30)),
             "Reminder completed 31 days ago must be filtered when maxCompletedTaskAgeDays=30. Without this, old completed reminders bypass the cutoff via the writeback path. (regression: #11 part 2)"
         )
     }
 
     /// Fallback path: when a completed task has no `completedDate`, the helper
     /// uses `lastModified` instead. Mirrors the source-scan behavior.
-    func testCompletedReminderWithoutCompletedDateFallsBackToLastModified() {
+    func testCompletedReminderWithoutCompletedDateFallsBackToLastModified() throws {
         var task = SyncTask(
             title: "Completed but no completedDate",
             isCompleted: true,
             completedDate: nil
         )
-        task.lastModified = daysAgo(60)
+        task.lastModified = try daysAgo(60)
         XCTAssertTrue(
-            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            SyncEngine.isCompletedTaskTooOld(task, cutoff: cutoff(maxAgeDays: 30)),
             "When completedDate is nil, lastModified must be consulted. The source-scan filter does this; writeback must match."
         )
     }
 
-    // MARK: - Recent completed reminders are kept (negative case)
-
     /// A reminder completed 5 days ago must NOT be filtered when the cutoff is
     /// 30 days. Catches over-filtering — i.e. the helper accidentally returning
     /// true for in-window tasks.
-    func testRecentCompletedReminderIsNotFiltered() {
+    func testRecentCompletedReminderIsNotFiltered() throws {
         let task = SyncTask(
             title: "Recently completed reminder",
             isCompleted: true,
-            completedDate: daysAgo(5)
+            completedDate: try daysAgo(5)
         )
         XCTAssertFalse(
-            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            SyncEngine.isCompletedTaskTooOld(task, cutoff: cutoff(maxAgeDays: 30)),
             "Reminder completed within the 30-day window must NOT be filtered — that would over-correct and hide legitimate recent work."
         )
     }
 
-    // MARK: - Uncompleted reminders are always kept
-
-    /// An uncompleted reminder must never be filtered by this helper, regardless
-    /// of how stale `lastModified` is. The age cutoff is about completion age
-    /// only; an open task is still actionable.
-    func testUncompletedReminderIsNeverFilteredEvenIfStale() {
+    /// An uncompleted reminder must never be filtered, regardless of how stale
+    /// `lastModified` is. The age cutoff is about completion age only.
+    func testUncompletedReminderIsNeverFilteredEvenIfStale() throws {
         var task = SyncTask(
             title: "Old open reminder",
             isCompleted: false,
             completedDate: nil
         )
-        task.lastModified = daysAgo(365)
+        task.lastModified = try daysAgo(365)
         XCTAssertFalse(
-            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            SyncEngine.isCompletedTaskTooOld(task, cutoff: cutoff(maxAgeDays: 30)),
             "Uncompleted tasks must never be age-filtered. Open work doesn't expire."
         )
     }
 
-    // MARK: - Disabled setting
-
-    /// `maxCompletedTaskAgeDays = 0` (the disabled sentinel) must short-circuit
-    /// to false. This preserves opt-in behavior — users who explicitly turn the
-    /// setting off get the old "sync everything" behavior, including via
-    /// writeback.
-    func testDisabledSettingNeverFilters() {
+    /// `maxCompletedTaskAgeDays = 0` (disabled) must short-circuit
+    /// `completedTaskCutoffDate(for:)` to nil, and the comparison helper must
+    /// then return false for everything.
+    func testDisabledSettingNeverFilters() throws {
         let task = SyncTask(
             title: "Ancient completed reminder",
             isCompleted: true,
-            completedDate: daysAgo(3650)
+            completedDate: try daysAgo(3650)
+        )
+        XCTAssertNil(
+            SyncEngine.completedTaskCutoffDate(for: config(maxAgeDays: 0)),
+            "Disabled setting must produce a nil cutoff so callers can skip the filter step entirely."
         )
         XCTAssertFalse(
-            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 0)),
-            "When maxCompletedTaskAgeDays is 0 (disabled), the helper must return false for everything — otherwise toggling the setting off would silently break sync."
+            SyncEngine.isCompletedTaskTooOld(task, cutoff: nil),
+            "A nil cutoff must always return false — otherwise toggling the setting off would silently break sync."
         )
     }
 
-    /// Boundary case: a task completed exactly `maxCompletedTaskAgeDays` ago
-    /// is inside the window. We use `<=` against the cutoff date, which is
-    /// `now - N days`, so a `completedDate` of exactly that point is treated as
-    /// too old (matches the source-scan semantics: source uses `>` to KEEP, so
-    /// equal-to-cutoff is dropped on source too — the helper must match).
-    func testBoundaryCaseMatchesSourceScanSemantics() {
-        // Reminder completed exactly at the cutoff instant. Source scan uses
-        // `completedDate > cutoffDate` to keep, so equal-to-cutoff is filtered.
-        // Helper must agree.
-        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
+    /// Boundary semantics: source scan uses `> cutoff` to KEEP, so equal-to-
+    /// cutoff is dropped. Helper uses `<= cutoff` to FILTER. These must agree.
+    func testBoundaryCaseMatchesSourceScanSemantics() throws {
+        let cutoffDate = try XCTUnwrap(gregorian.date(byAdding: .day, value: -30, to: Date()))
         var task = SyncTask(
             title: "Edge case",
             isCompleted: true,
-            completedDate: cutoff
+            completedDate: cutoffDate
         )
-        task.lastModified = cutoff
+        task.lastModified = cutoffDate
         XCTAssertTrue(
-            SyncEngine.isCompletedTaskTooOld(task, config: config(maxAgeDays: 30)),
+            SyncEngine.isCompletedTaskTooOld(task, cutoff: cutoffDate),
             "Boundary semantics must match source-scan filter. Source uses `> cutoff` to keep, so equal-to-cutoff is dropped; helper does the same with `<= cutoff`."
         )
     }
+
+    // MARK: - Integration tests (drive performSync via mock source/destination)
+
+    /// End-to-end: the writeback loop must skip old completed reminders and
+    /// append everything else. Without this test, a refactor that inverts the
+    /// `if SyncEngine.isCompletedTaskTooOld(...)` at the writeback site (or
+    /// removes the block) would silently re-introduce the bug — the helper
+    /// unit tests above all still pass in that case.
+    func testWritebackSkipsOldCompletedReminders() async throws {
+        let vault = try TempVault()
+        defer { vault.cleanup() }
+
+        let source = MockTaskSource()
+        let destination = MockTaskDestination(tasks: [
+            SyncTask(title: "old completed", isCompleted: true, completedDate: try daysAgo(60), remindersId: "r-old"),
+            SyncTask(title: "recent completed", isCompleted: true, completedDate: try daysAgo(5), remindersId: "r-recent"),
+            SyncTask(title: "open task", isCompleted: false, remindersId: "r-open"),
+        ])
+        let engine = SyncEngine(source: source, destination: destination, syncState: SyncState())
+
+        var cfg = config(maxAgeDays: 30)
+        cfg.vaultPath = vault.path
+
+        let result = await engine.performSync(config: cfg)
+
+        let appendedTitles = source.appendedTasks.map(\.title).sorted()
+        XCTAssertEqual(
+            appendedTitles, ["open task", "recent completed"],
+            "Writeback must append recent + open reminders and skip the old completed one. errors=\(result.errors)"
+        )
+        XCTAssertFalse(
+            appendedTitles.contains("old completed"),
+            "Old completed reminder must not reach appendNewTask — that's exactly the #68 regression."
+        )
+    }
+
+    /// The reorder (v5.8.2 dedup BEFORE age filter) must preserve the dedup's
+    /// `syncState.addOrUpdateMapping(...)` side-effect for old reminders whose
+    /// titles match an existing vault task. If a future refactor swaps the
+    /// order back, this assertion fails.
+    func testWritebackPreservesDedupMappingForOldMatchedReminders() async throws {
+        let vault = try TempVault()
+        defer { vault.cleanup() }
+
+        let matchingTitle = "weekly standup"
+        let existingVaultTask = SyncTask(
+            title: matchingTitle,
+            isCompleted: false,
+            tags: ["#work"],
+            obsidianSource: SyncTask.ObsidianSource(
+                filePath: "/Work.md",
+                lineNumber: 3,
+                originalLine: "- [ ] \(matchingTitle) #work"
+            )
+        )
+
+        let source = MockTaskSource(scannedTasks: [existingVaultTask])
+        let destination = MockTaskDestination(tasks: [
+            // Old completed reminder whose title matches a vault task.
+            SyncTask(title: matchingTitle, isCompleted: true, completedDate: try daysAgo(120), remindersId: "r-old-match"),
+        ])
+
+        let state = SyncState()
+        let engine = SyncEngine(source: source, destination: destination, syncState: state)
+
+        var cfg = config(maxAgeDays: 30)
+        cfg.vaultPath = vault.path
+
+        _ = await engine.performSync(config: cfg)
+
+        let existingObsidianId = source.generateTaskId(for: existingVaultTask)
+        XCTAssertNotNil(
+            state.findMapping(remindersId: "r-old-match"),
+            "Dedup must run BEFORE the age filter so an old completed reminder whose title matches a vault task still produces a syncState mapping. Otherwise that reminder appears unmapped on every sync and the 'Skipped N' count includes it forever. (regression: reorder)"
+        )
+        XCTAssertEqual(
+            state.findMapping(remindersId: "r-old-match")?.obsidianId,
+            existingObsidianId,
+            "Mapping must point at the matching vault task's obsidianId."
+        )
+        XCTAssertFalse(
+            source.appendedTasks.contains(where: { $0.title == matchingTitle }),
+            "An old completed reminder with a title match must NOT be appended — dedup skips, age skip would also skip."
+        )
+    }
+
+    /// Locks in the guard ordering: when `syncCompletedTasks = false`, the
+    /// existing first-line guard skips all completed reminders before our age
+    /// filter ever runs. The age filter is dead code in this path — but the
+    /// behavior is still correct (no completed reminder is appended). A future
+    /// refactor that removes the `syncCompletedTasks` half of that guard must
+    /// keep the age filter as the safety net.
+    func testWritebackUnreachableWhenSyncCompletedTasksFalse() async throws {
+        let vault = try TempVault()
+        defer { vault.cleanup() }
+
+        let source = MockTaskSource()
+        let destination = MockTaskDestination(tasks: [
+            SyncTask(title: "old completed", isCompleted: true, completedDate: try daysAgo(60), remindersId: "r-old"),
+            SyncTask(title: "open task", isCompleted: false, remindersId: "r-open"),
+        ])
+        let engine = SyncEngine(source: source, destination: destination, syncState: SyncState())
+
+        var cfg = config(maxAgeDays: 30)
+        cfg.syncCompletedTasks = false   // ← the path under test
+        cfg.vaultPath = vault.path
+
+        _ = await engine.performSync(config: cfg)
+
+        let appendedTitles = source.appendedTasks.map(\.title)
+        XCTAssertEqual(
+            appendedTitles, ["open task"],
+            "With syncCompletedTasks=false, completed reminders must be skipped by the existing guard — regardless of age. Only the open task should be appended."
+        )
+    }
+}
+
+// MARK: - Test fixtures
+
+/// Minimal disk fixture so `performSync` clears its `FileManager.default.fileExists(atPath:)`
+/// precondition on `config.vaultPath`. We never read from this directory in
+/// these tests — the mock source returns its own tasks — but the engine
+/// validates the path early.
+private final class TempVault {
+    let url: URL
+    var path: String { url.path }
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remindian-age-filter-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        // performSync validates this exists before scanning the vault.
+        try FileManager.default.createDirectory(
+            at: url.appendingPathComponent(".obsidian"),
+            withIntermediateDirectories: true
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+/// Minimal `TaskSource` that records every call to `appendNewTask` and returns
+/// a pre-seeded list from `scanTasks`. Other methods are unused by these tests
+/// and trap on call so a future expansion of the writeback path doesn't go
+/// unnoticed.
+private final class MockTaskSource: TaskSource {
+    let sourceName = "MockTaskSource"
+    private let scannedTasks: [SyncTask]
+    private(set) var appendedTasks: [SyncTask] = []
+
+    init(scannedTasks: [SyncTask] = []) {
+        self.scannedTasks = scannedTasks
+    }
+
+    func scanTasks(config: SyncConfiguration) throws -> [SyncTask] { scannedTasks }
+
+    func generateTaskId(for task: SyncTask) -> String {
+        // Deterministic, stable across calls — matches what real sources do.
+        return "mock-\(task.title)"
+    }
+
+    func markTaskComplete(task: SyncTask, completionDate: Date, config: SyncConfiguration) throws -> Int {
+        XCTFail("markTaskComplete should not be called by the writeback path"); return 0
+    }
+    func markTaskIncomplete(task: SyncTask, config: SyncConfiguration) throws {
+        XCTFail("markTaskIncomplete should not be called by the writeback path")
+    }
+    func updateTaskMetadata(task: SyncTask, changes: MetadataChanges, config: SyncConfiguration) throws {
+        XCTFail("updateTaskMetadata should not be called by the writeback path")
+    }
+
+    func appendNewTask(_ task: SyncTask, config: SyncConfiguration) throws -> SyncTask.ObsidianSource {
+        appendedTasks.append(task)
+        return SyncTask.ObsidianSource(
+            filePath: "Inbox.md",
+            lineNumber: appendedTasks.count,
+            originalLine: "- [ ] \(task.title)"
+        )
+    }
+
+    func hasFileChanged(task: SyncTask, since: Date, config: SyncConfiguration) -> Bool { false }
+}
+
+/// Minimal `TaskDestination` that returns a pre-seeded list from
+/// `fetchAllTasks`. All other methods are unused by these tests.
+private final class MockTaskDestination: TaskDestination {
+    let destinationName = "MockTaskDestination"
+    let tasks: [SyncTask]
+
+    init(tasks: [SyncTask]) { self.tasks = tasks }
+
+    func requestAccess() async throws -> Bool { true }
+    func fetchAllTasks() async throws -> [SyncTask] { tasks }
+    func getAvailableLists() async -> [String] { ["Reminders"] }
+
+    func createTask(from task: SyncTask, inList listName: String, config: SyncConfiguration) async throws -> String {
+        XCTFail("createTask should not be called by these tests"); return ""
+    }
+    // Legitimately called by the dedup-reconnect path in SyncEngine (Step 4)
+    // when a vault task title matches a destination reminder — the engine pushes
+    // the source-of-truth content back to the destination. No-op in tests.
+    func updateTask(withId id: String, from task: SyncTask, config: SyncConfiguration) async throws {}
+    func moveTask(withId id: String, toList listName: String) async throws {
+        XCTFail("moveTask should not be called by these tests")
+    }
+    func deleteTask(withId id: String) async throws {
+        XCTFail("deleteTask should not be called by these tests")
+    }
+    func refresh() {}
 }


### PR DESCRIPTION
Fixes #68.

## Summary

`maxCompletedTaskAgeDays` was only enforced on the source scan (Step 1), not on the Reminders → Obsidian writeback (Step 6). With `enableNewTaskWriteback = true` and a long history of completed reminders in Apple Reminders, every old completion was eligible for writeback into the source vault on next sync — recreating the exact symptom #11 was filed for (and that v3.3.0 only half-fixed by adding the setting itself).

Full bug report, repro, and `debug.log` evidence in #68.

## Fix

Extracted the inline source-side filter into `SyncEngine.isCompletedTaskTooOld(_:config:)` and reused it in the Step 6 writeback loop. Added a matching debug log line on the writeback side so it has the same observability as the source side.

## Tests

`RemindianTests/AgeFilterWritebackRegressionTests.swift` — 6 cases:
- old completed reminder is filtered (positive)
- recent completed reminder is kept (negative — guards against over-filtering)
- uncompleted reminder is never filtered, even with stale `lastModified`
- fallback to `lastModified` when `completedDate` is nil (mirrors source-scan behavior)
- disabled setting (`maxCompletedTaskAgeDays = 0`) short-circuits to false
- boundary case matches source-scan semantics (`<= cutoff` ⇔ source's `> cutoff` keep rule)

All existing tests still pass (`xcodebuild test -scheme Remindian -destination 'platform=macOS'` → `** TEST SUCCEEDED **`).

## End-to-end verification

Verified against a real vault that had hit the bug:
- Pre-patch: `Found 306 unmatched Reminders tasks for inbox writeback` → 306 ancient reminders written as TaskNote files.
- Post-patch (same vault, same config, fresh `sync_state.json`): `Found 296 unmatched Reminders tasks for inbox writeback` / `Skipped 270 old completed reminders from inbox writeback (older than 30 days)` / `Sync complete: 61 updated` — vault file count held steady at 63, no flood.

## Notes

- v5.8.2 fixed a different writeback bug (recurring-task instance loop in `/Inbox.md`). This patch is independent and additive — it sits before the v5.8.2 title-index dedup in Step 6 so the two cooperate cleanly.
- The new debug log line follows the existing source-side `Filtered out ...` pattern. Happy to drop it if you'd prefer silent skipping.
- Helper is `static internal` (default access) rather than `private` so the test file can call it directly via `@testable import Remindian`.