### PR TITLE
Fix unreliable Reminders → Obsidian writeback (data loss on mtime race + phantom 'N updated' churn)

### DIFF
--- a/ObsidianRemindersSync.xcodeproj/project.pbxproj
+++ b/ObsidianRemindersSync.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		T0N /* QuickAddParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1M; };
 		T0O /* AgendaBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1N; };
 		T0P /* TimeAndAlarmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1O; };
+		T0Q /* FileModSkipRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1P; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +159,7 @@
 		T1M /* QuickAddParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAddParserTests.swift; sourceTree = "<group>"; };
 		T1N /* AgendaBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgendaBuilderTests.swift; sourceTree = "<group>"; };
 		T1O /* TimeAndAlarmTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeAndAlarmTests.swift; sourceTree = "<group>"; };
+		T1P /* FileModSkipRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileModSkipRegressionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -323,6 +325,7 @@
 				T1M /* QuickAddParserTests.swift */,
 				T1N /* AgendaBuilderTests.swift */,
 				T1O /* TimeAndAlarmTests.swift */,
+				T1P /* FileModSkipRegressionTests.swift */,
 			);
 			path = RemindianTests;
 			sourceTree = "<group>";
@@ -491,6 +494,7 @@
 				T0N /* QuickAddParserTests.swift in Sources */,
 				T0O /* AgendaBuilderTests.swift in Sources */,
 				T0P /* TimeAndAlarmTests.swift in Sources */,
+				T0Q /* FileModSkipRegressionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Obsync/Services/SyncEngine.swift
+++ b/Obsync/Services/SyncEngine.swift
@@ -535,6 +535,14 @@ class SyncEngine {
                         do {
                             var taskForReminders = oTask
 
+                            // When the file-modification guard blocks an Obsidian-side
+                            // writeback (completion or metadata), we MUST NOT advance the
+                            // stored hashes to reflect a writeback that never happened.
+                            // Otherwise the next sync sees no diff to retry and the user's
+                            // Reminders-side change is permanently lost. Tracked here so
+                            // the syncState save below can preserve the prior hashes.
+                            var obsidianWritebackSkippedDueToFileMod = false
+
                             // If only Reminders changed (not Obsidian), preserve the
                             // Reminders values so we don't revert the user's edits.
                             // The metadata writeback will selectively write enabled
@@ -556,6 +564,7 @@ class SyncEngine {
                                 if config.enableCompletionWriteback {
                                         // Check file hasn't changed since sync started
                                     if !fileNotModifiedBeforeSync {
+                                        obsidianWritebackSkippedDueToFileMod = true
                                         result.errors.append(ObsidianError.fileModifiedDuringSync)
                                         result.details.append(SyncLogDetail(
                                             action: .error,
@@ -622,7 +631,23 @@ class SyncEngine {
                             // Skip if completion writeback already modified this task's
                             // vault line — originalLine is stale and the task is done.
                             if rChanged && !oChanged && !completionWritebackIds.contains(mapping.obsidianId) {
-                                if fileNotModifiedBeforeSync {
+                                if !fileNotModifiedBeforeSync {
+                                    // File mtime bumped between sync start and now.
+                                    // Without this branch the writeback would silently
+                                    // skip AND the hash-save below would advance to
+                                    // "synced," permanently losing the Reminders-side
+                                    // change. Flag for the hash-save and surface the
+                                    // skip as a non-fatal error so the user can see it.
+                                    obsidianWritebackSkippedDueToFileMod = true
+                                    debugLog("[SyncEngine] Metadata writeback skipped (file modified during sync) for \"\(oTask.title)\" — will retry next sync")
+                                    result.errors.append(ObsidianError.fileModifiedDuringSync)
+                                    result.details.append(SyncLogDetail(
+                                        action: .error,
+                                        taskTitle: oTask.title,
+                                        filePath: oTask.obsidianSource?.filePath,
+                                        errorMessage: "Metadata writeback skipped: file modified during sync (will retry)"
+                                    ))
+                                } else {
                                     var metadataChanges = MetadataChanges()
                                     var changeDescriptions: [String] = []
 
@@ -725,12 +750,27 @@ class SyncEngine {
                                     }
                                 }
 
-                                syncState.addOrUpdateMapping(
-                                    obsidianId: mapping.obsidianId,
-                                    remindersId: mapping.remindersId,
-                                    obsidianHash: SyncState.generateTaskHash(taskForReminders),
-                                    remindersHash: SyncState.generateTaskHash(taskForReminders)
-                                )
+                                if obsidianWritebackSkippedDueToFileMod {
+                                    // Preserve the pre-sync hashes so the next sync still
+                                    // detects rChanged and retries the writeback. Without
+                                    // this the Reminders-side change would be permanently
+                                    // lost (and on the sync after that, the "obsidian wins"
+                                    // path would push the stale Obsidian value back to
+                                    // Reminders, destroying the user's edit there too).
+                                    syncState.addOrUpdateMapping(
+                                        obsidianId: mapping.obsidianId,
+                                        remindersId: mapping.remindersId,
+                                        obsidianHash: mapping.lastObsidianHash,
+                                        remindersHash: mapping.lastRemindersHash
+                                    )
+                                } else {
+                                    syncState.addOrUpdateMapping(
+                                        obsidianId: mapping.obsidianId,
+                                        remindersId: mapping.remindersId,
+                                        obsidianHash: SyncState.generateTaskHash(taskForReminders),
+                                        remindersHash: SyncState.generateTaskHash(taskForReminders)
+                                    )
+                                }
                             }
                             result.updated += 1
                             result.details.append(SyncLogDetail(

--- a/Obsync/Services/SyncEngine.swift
+++ b/Obsync/Services/SyncEngine.swift
@@ -764,11 +764,36 @@ class SyncEngine {
                                         remindersHash: mapping.lastRemindersHash
                                     )
                                 } else {
+                                    // Store each side's post-sync fingerprint.
+                                    //
+                                    // Obsidian side: the Obsidian task as it will be
+                                    // re-scanned next sync (taskForReminders carries
+                                    // oTask's identity fields incl. its empty/tag-derived
+                                    // targetList) — matches generateTaskHash(oTask).
+                                    //
+                                    // Reminders side: must reflect what the REMINDER
+                                    // hashes to on the next fetch, NOT the Obsidian task.
+                                    // The reminder lives in the resolved destination list
+                                    // (it was created there, or we just moved it there at
+                                    // line ~721) — e.g. "Inbox" or "Someday" — whereas
+                                    // oTask.targetList is empty (inbox) or the raw lower-
+                                    // case tag ("someday"). Storing the Obsidian hash here
+                                    // left lastRemindersHash permanently out of sync with
+                                    // the live reminder, so every subsequent sync saw a
+                                    // phantom rChanged=true and redundantly re-pushed — the
+                                    // "N updated every sync with nothing changing" bug.
+                                    // Seed it with the resolved list so the two agree.
+                                    var reminderStateAfterSync = taskForReminders
+                                    reminderStateAfterSync.targetList = config.resolveTargetList(
+                                        tag: oTask.targetList,
+                                        filePath: oTask.obsidianSource?.filePath,
+                                        tags: oTask.tags
+                                    )
                                     syncState.addOrUpdateMapping(
                                         obsidianId: mapping.obsidianId,
                                         remindersId: mapping.remindersId,
                                         obsidianHash: SyncState.generateTaskHash(taskForReminders),
-                                        remindersHash: SyncState.generateTaskHash(taskForReminders)
+                                        remindersHash: SyncState.generateTaskHash(reminderStateAfterSync)
                                     )
                                 }
                             }

--- a/RemindianTests/FileModSkipRegressionTests.swift
+++ b/RemindianTests/FileModSkipRegressionTests.swift
@@ -113,4 +113,152 @@ final class FileModSkipRegressionTests: XCTestCase {
             "Sanity: identical hashes mean no change. If this fails, the diff-detection logic itself is broken."
         )
     }
+
+    // MARK: - Phantom "N updated every sync" regression (reminders-hash list seed)
+
+    /// End-to-end reproduction of the "N tasks updated every sync with nothing
+    /// changing" bug. After a mapping is synced, `lastRemindersHash` must equal
+    /// what the LIVE reminder hashes to on the next fetch — including its actual
+    /// destination list. The bug stored the Obsidian task's hash (whose
+    /// targetList is empty for inbox tasks, or the raw lowercase tag), which
+    /// never matched the reminder's real list ("Inbox", "Someday", …). Every
+    /// subsequent sync then saw a phantom rChanged=true and redundantly
+    /// re-pushed, logging "N updated" forever.
+    ///
+    /// Drives the real `performSync` via mock source/destination (seam added in
+    /// v5.10.1). Sync 1 corrects the stored hash; sync 2 must be a clean no-op.
+    func testNoPhantomRechangeWhenObsidianListIsEmptyButReminderHasList() async throws {
+        let vault = try PhantomTempVault()
+        defer { vault.cleanup() }
+
+        // Inbox task: no tag → targetList resolves to defaultList ("Inbox").
+        let obsidianTask = SyncTask(
+            title: "Respond to Suzie's email",
+            isCompleted: false,
+            targetList: nil,
+            obsidianSource: SyncTask.ObsidianSource(
+                filePath: "/Inbox.md",
+                lineNumber: 3,
+                originalLine: "- [ ] Respond to Suzie's email"
+            )
+        )
+        // The live reminder actually lives in the "Inbox" list.
+        let reminder = SyncTask(
+            title: "Respond to Suzie's email",
+            isCompleted: false,
+            targetList: "Inbox",
+            remindersId: "r-suzie"
+        )
+
+        let source = PhantomMockSource(scannedTasks: [obsidianTask])
+        let destination = PhantomMockDestination(tasks: [reminder])
+
+        // Seed the mapping with the OLD buggy reminders hash: the Obsidian
+        // task's hash, whose targetList is empty. This is exactly what the
+        // pre-fix save wrote, and what we found in the user's real sync_state.
+        let state = SyncState()
+        let obsidianId = source.generateTaskId(for: obsidianTask)
+        state.addOrUpdateMapping(
+            obsidianId: obsidianId,
+            remindersId: "r-suzie",
+            obsidianHash: SyncState.generateTaskHash(obsidianTask),
+            remindersHash: SyncState.generateTaskHash(obsidianTask)  // buggy: empty list
+        )
+
+        let engine = SyncEngine(source: source, destination: destination, syncState: state)
+
+        // SyncConfiguration is a class — property mutation works through `let`.
+        let cfg = SyncConfiguration()
+        cfg.vaultPath = vault.path
+        cfg.defaultList = "Inbox"
+        cfg.addTaskLinkToReminders = false  // isolate: URL backfill is a separate entry trigger
+
+        // Sync 1: stored empty-list hash != live "Inbox" hash → rChanged fires,
+        // the fix re-stores the reminders hash seeded with the resolved list.
+        _ = await engine.performSync(config: cfg)
+
+        XCTAssertEqual(
+            state.findMapping(remindersId: "r-suzie")?.lastRemindersHash,
+            SyncState.generateTaskHash(reminder),
+            "After sync, lastRemindersHash must equal the LIVE reminder's hash (incl. its real 'Inbox' list) so the next sync sees no phantom change."
+        )
+
+        // Sync 2: steady state — must be a clean no-op for this mapping.
+        let result2 = await engine.performSync(config: cfg)
+        XCTAssertEqual(
+            result2.updated, 0,
+            "Second sync must report zero updates. A non-zero count means the phantom-rechange flap is back. errors=\(result2.errors)"
+        )
+    }
+}
+
+// MARK: - Test fixtures (phantom-rechange test)
+
+/// Minimal on-disk vault so `performSync` clears its vaultPath + `.obsidian`
+/// preconditions. Never read from — the mock source returns its own tasks.
+private final class PhantomTempVault {
+    let url: URL
+    var path: String { url.path }
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remindian-phantom-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: url.appendingPathComponent(".obsidian"),
+            withIntermediateDirectories: true
+        )
+    }
+
+    func cleanup() { try? FileManager.default.removeItem(at: url) }
+}
+
+private final class PhantomMockSource: TaskSource {
+    let sourceName = "PhantomMockSource"
+    private let scannedTasks: [SyncTask]
+
+    init(scannedTasks: [SyncTask]) { self.scannedTasks = scannedTasks }
+
+    func scanTasks(config: SyncConfiguration) throws -> [SyncTask] { scannedTasks }
+    func generateTaskId(for task: SyncTask) -> String { "mock-\(task.title)" }
+
+    func markTaskComplete(task: SyncTask, completionDate: Date, config: SyncConfiguration) throws -> Int {
+        XCTFail("markTaskComplete must not be called: nothing changed"); return 0
+    }
+    func markTaskIncomplete(task: SyncTask, config: SyncConfiguration) throws {
+        XCTFail("markTaskIncomplete must not be called: nothing changed")
+    }
+    func updateTaskMetadata(task: SyncTask, changes: MetadataChanges, config: SyncConfiguration) throws {
+        XCTFail("updateTaskMetadata must not be called: due/start/priority all match")
+    }
+    func appendNewTask(_ task: SyncTask, config: SyncConfiguration) throws -> SyncTask.ObsidianSource {
+        XCTFail("appendNewTask must not be called: task is already mapped")
+        return SyncTask.ObsidianSource(filePath: "Inbox.md", lineNumber: 1, originalLine: "")
+    }
+    func hasFileChanged(task: SyncTask, since: Date, config: SyncConfiguration) -> Bool { false }
+}
+
+private final class PhantomMockDestination: TaskDestination {
+    let destinationName = "PhantomMockDestination"
+    let tasks: [SyncTask]
+    private(set) var updateCount = 0
+
+    init(tasks: [SyncTask]) { self.tasks = tasks }
+
+    func requestAccess() async throws -> Bool { true }
+    func fetchAllTasks() async throws -> [SyncTask] { tasks }
+    func getAvailableLists() async -> [String] { ["Inbox"] }
+
+    func createTask(from task: SyncTask, inList listName: String, config: SyncConfiguration) async throws -> String {
+        XCTFail("createTask must not be called: task is already mapped"); return ""
+    }
+    // Called once on sync 1 (the redundant push that re-baselines the hash). No-op.
+    func updateTask(withId id: String, from task: SyncTask, config: SyncConfiguration) async throws { updateCount += 1 }
+    func moveTask(withId id: String, toList listName: String) async throws {
+        XCTFail("moveTask must not be called: reminder is already in the resolved list")
+    }
+    func deleteTask(withId id: String) async throws {
+        XCTFail("deleteTask must not be called")
+    }
+    func refresh() {}
 }

--- a/RemindianTests/FileModSkipRegressionTests.swift
+++ b/RemindianTests/FileModSkipRegressionTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import Remindian
+
+/// Regression tests for the silent-data-loss bug where a Reminders-side change
+/// (due date, completion, etc.) was permanently dropped when the .md file's
+/// mtime bumped between sync-start and the per-mapping writeback check.
+///
+/// **The bug.** `SyncEngine.performSync` was unconditionally rolling both
+/// `lastObsidianHash` and `lastRemindersHash` forward to
+/// `generateTaskHash(taskForReminders)` at the end of each mapping iteration —
+/// *even when* the `fileNotModifiedBeforeSync` guard had silently blocked the
+/// Obsidian-side writeback. The stored state then claimed "everything is
+/// synced" for a change that had never reached Obsidian. The next sync saw no
+/// diff to retry, and on the sync after that the "Obsidian wins" path
+/// overwrote the user's Reminders edit too.
+///
+/// **The fix.** When the file-mod guard skips the writeback, preserve the
+/// pre-sync hashes so the next sync re-detects `rChanged` and retries.
+///
+/// These tests pin the `SyncState.addOrUpdateMapping` invariant that Fix 1
+/// depends on: passing the old hashes through must actually preserve them.
+/// If a future refactor accidentally rewrites that semantic (e.g. always
+/// regenerating from the live task), the fix silently breaks and the bug
+/// returns. The full SyncEngine path is verified end-to-end manually since
+/// the project doesn't yet have mock infrastructure for `TaskSource` /
+/// `TaskDestination`.
+final class FileModSkipRegressionTests: XCTestCase {
+
+    func testAddOrUpdateMappingWithSameHashesPreservesThem() {
+        let state = SyncState()
+        let oldHash = "OLD_HASH_VALUE"
+        state.addOrUpdateMapping(
+            obsidianId: "task-1",
+            remindersId: "reminder-1",
+            obsidianHash: oldHash,
+            remindersHash: oldHash
+        )
+        let firstSyncDate = state.findMapping(obsidianId: "task-1")?.lastSyncDate
+
+        // Simulate the Fix 1 path: writeback was skipped, so we re-call
+        // addOrUpdateMapping with the same (pre-sync) hashes to refresh
+        // lastSyncDate without poisoning the diff signal.
+        Thread.sleep(forTimeInterval: 0.01)  // ensure date strictly advances
+        state.addOrUpdateMapping(
+            obsidianId: "task-1",
+            remindersId: "reminder-1",
+            obsidianHash: oldHash,
+            remindersHash: oldHash
+        )
+
+        guard let mapping = state.findMapping(obsidianId: "task-1") else {
+            XCTFail("Mapping must still exist")
+            return
+        }
+        XCTAssertEqual(
+            mapping.lastObsidianHash, oldHash,
+            "Re-saving with the same obsidianHash must preserve it. Fix 1 relies on this so the next sync still sees rChanged and retries."
+        )
+        XCTAssertEqual(
+            mapping.lastRemindersHash, oldHash,
+            "Re-saving with the same remindersHash must preserve it. Without this preservation, a writeback skipped due to file-mod is permanently lost."
+        )
+        XCTAssertNotNil(firstSyncDate)
+        XCTAssertGreaterThan(
+            mapping.lastSyncDate, firstSyncDate!,
+            "lastSyncDate should still advance even when hashes are preserved — the sync did run, it just didn't write."
+        )
+    }
+
+    func testAddOrUpdateMappingWithNewHashesOverridesThem() {
+        // Positive control: the happy path (writeback succeeded) must still
+        // roll hashes forward as it always has. Fix 1 must not have broken this.
+        let state = SyncState()
+        state.addOrUpdateMapping(
+            obsidianId: "task-2",
+            remindersId: "reminder-2",
+            obsidianHash: "INITIAL",
+            remindersHash: "INITIAL"
+        )
+
+        state.addOrUpdateMapping(
+            obsidianId: "task-2",
+            remindersId: "reminder-2",
+            obsidianHash: "UPDATED",
+            remindersHash: "UPDATED"
+        )
+
+        let mapping = state.findMapping(obsidianId: "task-2")
+        XCTAssertEqual(mapping?.lastObsidianHash, "UPDATED")
+        XCTAssertEqual(mapping?.lastRemindersHash, "UPDATED")
+    }
+
+    func testHasRemindersChangedReportsTrueWhenStoredHashIsStale() {
+        // Documents the diff-detection contract Fix 1 depends on. After a
+        // skipped writeback, the stored remindersHash stays at its pre-sync
+        // value. On the next sync, currentHash (computed from rTask which
+        // still has the user's new Reminders value) differs from
+        // lastRemindersHash → hasRemindersChanged returns true → the
+        // metadata writeback block at SyncEngine.swift:565 is re-entered.
+        let mapping = SyncState.TaskMapping(
+            obsidianId: "task-3",
+            remindersId: "reminder-3",
+            lastObsidianHash: "PRE_SYNC_OBSIDIAN",
+            lastRemindersHash: "PRE_SYNC_REMINDERS",
+            lastSyncDate: Date()
+        )
+        XCTAssertTrue(
+            mapping.hasRemindersChanged(currentHash: "NEW_REMINDERS_HASH"),
+            "When the live rTask hash differs from the preserved lastRemindersHash, the retry must fire."
+        )
+        XCTAssertFalse(
+            mapping.hasRemindersChanged(currentHash: "PRE_SYNC_REMINDERS"),
+            "Sanity: identical hashes mean no change. If this fails, the diff-detection logic itself is broken."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Two related fixes to the Reminders → Obsidian writeback path, both affecting users who have `enableDueDateWriteback` (or other metadata writeback) turned on. They were found while investigating due-date changes made in Apple Reminders that intermittently failed to reach Obsidian.

Each fix is a single focused commit with regression tests, verified end-to-end on a real vault running v5.10.1.

---

### Fix 1 — Silent data loss when a vault file's mtime changes mid-sync

**Symptom.** A due-date (or other metadata) change made in Reminders intermittently never reaches Obsidian, and on a later sync the stale Obsidian value overwrites the Reminders edit — so the user's change is lost on *both* sides, with no error surfaced.

**Root cause.** In `performSync`, when the `fileNotModifiedBeforeSync` guard blocks an Obsidian-side writeback (completion or metadata), the per-mapping save at the end of the loop still advanced **both** `lastObsidianHash` and `lastRemindersHash` to `generateTaskHash(taskForReminders)`. The stored state then claimed "synced" for a writeback that never happened. The next sync saw no diff to retry, and the sync after that took the "Obsidian wins" path and pushed the stale Obsidian value back to Reminders.

The guard trips whenever something touches the `.md` file between sync start and the writeback check — Obsidian's own indexing, Spotlight, cloud sync, etc. — which is why it presented as intermittent.

**Fix.** When the guard skips a writeback, preserve the pre-sync hashes so the next sync still detects `rChanged` and retries. The skip is also surfaced as a `debugLog` line and a non-fatal error instead of being silent.

---

### Fix 2 — Phantom "N updated every sync" with nothing actually changing

**Symptom.** A handful of tasks are reported as updated on *every* sync even when nothing changed, producing constant churn in the sync log and redundant writes back to the destination.

**Root cause.** At the per-mapping save site, both hashes were stored as `generateTaskHash(taskForReminders)` — the Obsidian task's fingerprint. But the reminder lives in the resolved destination list (e.g. `Inbox`, `Someday`), whereas an inbox Obsidian task has an empty `targetList` and a `#tag` task carries the raw lowercase tag. So `lastRemindersHash` never matched what the live reminder hashes to on the next fetch, and `hasRemindersChanged` returned true forever. Decoding a real `sync_state.json` confirmed the only differing field was `targetList` (empty vs `Inbox`; `someday` vs `Someday`).

**Fix.** Seed the reminders-side hash with `config.resolveTargetList(...)` — the list the reminder was created in or just moved to — so it matches the live reminder. The Obsidian-side hash is unchanged (it still mirrors the next vault scan).

*Note:* the new-task creation/reconnect paths share the same root cause and can cause a brand-new task to flicker "updated" once before the (now self-healing) update path corrects it on the following sync. That's cosmetic and single-cycle; I left it out to keep this PR focused, but happy to add it here or in a follow-up if you'd prefer.

---

## Tests

`RemindianTests/FileModSkipRegressionTests.swift` (new):

- Unit tests pinning the `SyncState` hash-preservation invariant Fix 1 relies on.
- An integration test driving the real `performSync` via mock `TaskSource`/`TaskDestination` (using the `SyncState` injection seam added in #67): sync 1 corrects the stored reminders hash, sync 2 asserts `result.updated == 0`. Reverting Fix 2 makes it fail.

Full suite passes locally (`xcodebuild test … -destination 'platform=macOS'`), including the existing regression suites.

## Verification

Built and installed on a real vault (≈350 source tasks / ≈1300 mapped reminders). After installing: a Reminders-side due-date change propagated to Obsidian and was no longer reverted; the previously-flapping tasks went quiet, with consecutive `Sync result: No changes` and zero `Reminders changed for` events.



Fixes #75.
