### PR TITLE
Fix DMG download path & inaccurate description for Homebrew Cask

### DIFF
--- a/Cask/remindian.rb
+++ b/Cask/remindian.rb
@@ -8,7 +8,7 @@ cask "remindian" do
   homepage "https://github.com/Santofer/Remindian"
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Remindian.app"
 

--- a/Cask/remindian.rb
+++ b/Cask/remindian.rb
@@ -2,9 +2,9 @@ cask "remindian" do
   version "5.25.13"
   sha256 "3a3fbdf98fb3ce812a2cfc97c837c77e438dc74fa2fcdeef7e58f6a53d0fd724"
 
-  url "https://github.com/Santofer/Remindian/releases/download/v#{version}/Remindian-v#{version}.dmg"
+  url "https://github.com/Santofer/Remindian/releases/download/v#{version}/Remindian-#{version}.dmg"
   name "Remindian"
-  desc "Sync Obsidian tasks with Apple Reminders, Todoist, Asana, Linear, and more"
+  desc "Sync Obsidian tasks with Apple Reminders, Things 3, Todoist, and TickTick"
   homepage "https://github.com/Santofer/Remindian"
 
   auto_updates true

--- a/scripts/update-casks.sh
+++ b/scripts/update-casks.sh
@@ -9,7 +9,7 @@
 #   scripts/update-casks.sh <version> <path-to-dmg>
 #
 # Example:
-#   scripts/update-casks.sh 5.12.0 dist/Remindian-v5.12.0.dmg
+#   scripts/update-casks.sh 5.12.0 dist/Remindian-5.12.0.dmg
 #
 # Idempotent and safe to re-run. Requires: shasum, git, gh (authenticated).
 set -euo pipefail


### PR DESCRIPTION
### Symptom
<img width="898" height="82" alt="image" src="https://github.com/user-attachments/assets/8d163dc3-83e5-4c6c-b4e5-db6b48450aaf" />
Using `brew install --cask Santofer/tap/remindian` fails, as shown above.

### Cause
Looking back at the release history, [5.21.0](https://github.com/Santofer/Remindian/releases/tag/v5.21.0) was the last to have 'v' preceding the version string. 
<img width="227" height="175" alt="image" src="https://github.com/user-attachments/assets/686ce7d2-66c9-4767-917d-2218d7a537b6" />

Since [5.21.1](https://github.com/Santofer/Remindian/releases/tag/v5.21.1), the preceding 'v' is no longer present.
<img width="245" height="186" alt="image" src="https://github.com/user-attachments/assets/fb5e12a0-c3d6-4a03-8fa5-cb2fdcf5051b" />

---

### Changes

- Tweaked the [update script](scripts/update-casks.sh) to remove the errant 'v'.
- In addition to this fix, I changed the cask description, which appears to have been hallucinated as it's distinct from [the destinations in the README](README.md#-destinations).
- Homebrew was throwing a warning about deprecated `depends_on` syntax, now corrected.
<img width="894" height="50" alt="image" src="https://github.com/user-attachments/assets/106813c7-d764-4d88-bf4e-f7c163573b3c" />

### Impact

Fixes #84.